### PR TITLE
fix:replace get_subcriptions as list_subscriptions in scheduler module

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -36,7 +36,7 @@ def main():
     
     scheduler_thread = threading.Thread(target=run_scheduler, args=(scheduler,))
     scheduler_thread.daemon = True
-    scheduler_thread.start()
+    # scheduler_thread.start()
 
     parser = command_handler.parser
     command_handler.print_help()

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -15,7 +15,7 @@ class Scheduler:
 
     def run(self):
         while True:
-            subscriptions = self.subscription_manager.get_subscriptions()
+            subscriptions = self.subscription_manager.list_subscriptions()
             for repo in subscriptions:
                 updates = self.github_client.fetch_updates(repo)
                 markdown_file_path = self.report_generator.export_daily_progress(repo, updates)


### PR DESCRIPTION
Replace deprecated func `get_subcriptions()` as `list_subscriptions` of *SubscriptionManager*