### PR TITLE
Fix bugs: command 'fetch' can't get the argument 'repo'

### DIFF
--- a/src/command_handler.py
+++ b/src/command_handler.py
@@ -28,6 +28,7 @@ class CommandHandler:
         parser_list.set_defaults(func=self.list_subscriptions)
 
         parser_fetch = subparsers.add_parser('fetch', help='Fetch updates immediately')
+        parser_fetch.add_argument('repo', type=str, help='The repository to fetch updates from (e.g., owner/repo)')
         parser_fetch.set_defaults(func=self.fetch_updates)
 
         parser_export = subparsers.add_parser('export', help='Export daily progress')
@@ -58,9 +59,10 @@ class CommandHandler:
             print(f"  - {sub}")
 
     def fetch_updates(self, args):
-        updates = self.github_client.fetch_updates()
+        updates = self.github_client.fetch_updates(args.repo)
         for update in updates:
             print(update)
+
 
     def export_daily_progress(self, args):
         self.github_client.export_daily_progress(args.repo)


### PR DESCRIPTION
The command 'fetch' cannot retrieve the parameter 'repo', causing the command 'fetch' to be unable to obtain project issue and other information from the project code repository.